### PR TITLE
provide json list of jobs

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -7,6 +7,7 @@ class JobsController < ApplicationController
 			format.html
 			format.rss
 			format.js
+			format.json { render json: @jobs }
 		end
 	end
 

--- a/spec/controllers/jobs_controller_spec.rb
+++ b/spec/controllers/jobs_controller_spec.rb
@@ -19,6 +19,11 @@ describe JobsController do
 			response.should be_success
 		end
 
+		it 'should render correctly as JSON' do
+			get :index, :format => :json
+			response.should be_success
+		end
+
 		it "should assign a jobs collection" do
 			assigns[:jobs].should_not be_nil
 			assigns[:jobs][0].should == @job


### PR DESCRIPTION
Provide job list in json format, to be consumable by the rubyireland.com page instead of using bloople.net to read the rss feed.
