### PR TITLE
Add coveralls and travis for ci builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 # Ignore all logfiles and tempfiles.
 /log/*.log
 /tmp
+/coverage
 
 .DS_Store
 .env

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: ruby
+rvm:
+  - 1.9.3
+before_install:
+  - "export DISPLAY=:99.0"
+  - "bundle install"
+  - "bundle exec rake db:migrate RAILS_ENV=test"
+  - "bundle exec rspec spec"
+env:
+  global:
+    - DISPLAY=:99.0

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :development, :test do
   gem 'factory_girl'
   gem 'rspec-rails'
   gem 'capybara'
+  gem 'coveralls', require: false
 end
 
 group :assets do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,13 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.4.0)
+    colorize (0.5.8)
+    coveralls (0.6.7)
+      colorize
+      multi_json (~> 1.3)
+      rest-client
+      simplecov (>= 0.7)
+      thor
     daemons (1.1.9)
     diff-lcs (1.1.3)
     dynamic_form (1.1.4)
@@ -103,6 +110,8 @@ GEM
     rake (10.0.3)
     rdoc (3.12.1)
       json (~> 1.4)
+    rest-client (1.6.7)
+      mime-types (>= 1.16)
     rspec-core (2.12.2)
     rspec-expectations (2.12.1)
       diff-lcs (~> 1.1.3)
@@ -130,6 +139,10 @@ GEM
     shoulda-matchers (1.4.2)
       activesupport (>= 3.0.0)
       bourne (~> 1.1.2)
+    simplecov (0.7.1)
+      multi_json (~> 1.0)
+      simplecov-html (~> 0.7.1)
+    simplecov-html (0.7.1)
     sprockets (2.2.2)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -160,6 +173,7 @@ DEPENDENCIES
   RedCloth (~> 4.2.9)
   capybara
   coffee-rails (~> 3.2.2)
+  coveralls
   dynamic_form (~> 1.1.4)
   factory_girl
   jquery-rails (~> 2.2.1)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,8 @@
 ENV["RAILS_ENV"] ||= 'test'
+
+require 'coveralls'
+Coveralls.wear!
+
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'rspec/autorun'


### PR DESCRIPTION
- Added coveralls
- Added travis settings
- modified gitignore file to ignore coverage files

You should be able to update the readme with build/coverage pngs when the coveralls/travis hooks are setup for this repo (coveralls.io and travis-ci.org).
